### PR TITLE
feat: add geometry_api_bridge, a syside-free sysmlv2-backed alternative

### DIFF
--- a/src/geometry_api_bridge/__init__.py
+++ b/src/geometry_api_bridge/__init__.py
@@ -1,0 +1,3 @@
+"""Public package interface for geometry_api_bridge."""
+
+from .geometry_api_bridge import *

--- a/src/geometry_api_bridge/geometry_api_bridge.py
+++ b/src/geometry_api_bridge/geometry_api_bridge.py
@@ -1,0 +1,356 @@
+"""sysmlv2-native equivalent of geometry_api, with no Syside dependency at all.
+
+Mirrors `geometry_api`'s public API exactly (`Component`, `create_component`,
+`get_sysmlv2_text`, `clear_components`, `load_from_sysml`,
+`components_from_part_world`) so callers can pick between the two modules
+based on which SysML v2 engine they're using — e.g.:
+
+    if backend == "sysmlv2":
+        from geometry_api_bridge import load_from_sysml, components_from_part_world
+    else:
+        from geometry_api.geometry_api import load_from_sysml, components_from_part_world
+
+`Component`/`create_component`/`get_sysmlv2_text`/`clear_components` are
+plain Python bookkeeping and string templating — identical to `geometry_api`'s
+versions, duplicated here (rather than imported from `geometry_api`) so this
+module has zero dependency on Syside, full stop.
+
+`load_from_sysml`/`components_from_part_world` walk a
+`sysmlv2_flexo_bridge` (github.com/planetaryutilities/sysmlv2_flexo_bridge)
+`JsonElement` tree — the interchange-JSON equivalent of the live Syside
+PartUsage/AttributeUsage AST `geometry_api`'s versions walk — using
+`sysmlv2_flexo_bridge_engine.evaluate_attributes()` in place of
+`syside.Compiler().evaluate()` for expression-valued attributes.
+sysmlv2_flexo_bridge is imported lazily, only inside those two functions, so
+this module still doesn't need it just for the bookkeeping half.
+"""
+
+from astropy.coordinates import CartesianRepresentation
+from typing import List, Optional, Dict
+import math
+import numpy as np
+from transformation_api.transformations import transformation_matrix, euler_from_matrix  # uses 'sxyz' by default
+
+_components: Dict[str, "Component"] = {}
+
+pu_geometry_pkg = '''
+
+    part def Onshape_Component {
+        attribute onshape_url;
+    }
+    part def Omniverse_Component {
+        attribute ov_filepath;
+    }
+
+    part def Component{
+        attribute tx;
+        attribute ty;
+        attribute tz;
+
+        attribute rx;
+        attribute ry;
+        attribute rz;
+
+        attribute typeID;
+        part children: Component[0..*];
+    }
+'''
+
+
+class Component:
+    def __init__(
+        self,
+        name: str,
+        typeID: int,
+        translation: CartesianRepresentation,
+        rotation: CartesianRepresentation,
+        parent: Optional["Component"] = None,
+        extra_attrs: Optional[Dict] = None,
+    ):
+        self.name = name
+        self.typeID = typeID
+        self.translation = translation
+        self.rotation = rotation
+        self.parent = parent
+        self.children: List[Component] = []
+        self.extra_attrs: Dict = extra_attrs or {}
+
+        if parent:
+            parent.children.append(self)
+
+    def to_textual(self, indent: int = 0) -> str:
+        ind = " " * indent
+        lines = [
+            f"{ind}part {self.name}: Onshape_Component, Omniverse_Component subsets children {{",
+            f"{ind}    attribute :>> tx={self.translation.x};",
+            f"{ind}    attribute :>> ty={self.translation.y};",
+            f"{ind}    attribute :>> tz={self.translation.z};",
+            f"{ind}    attribute :>> rx={self.rotation.x};",
+            f"{ind}    attribute :>> ry={self.rotation.y};",
+            f"{ind}    attribute :>> rz={self.rotation.z};",
+            f"{ind}    attribute :>> typeID = {self.typeID};",
+        ]
+        for key, val in self.extra_attrs.items():
+            lines.append(f"{ind}    attribute {key} = {val!r};")
+        for child in self.children:
+            lines.append(child.to_textual(indent + 4))
+        lines.append(f"{ind}}}")
+        return "\n".join(lines)
+
+
+def create_component(
+    name: str,
+    typeID: int,
+    translation_data: Dict[str, float],
+    rotation_data: Dict[str, float],
+    parent_name: Optional[str] = None,
+    extra_attrs: Optional[Dict] = None,
+) -> str:
+    """
+    API endpoint to create a new geometric component and optionally attach it to a parent.
+    """
+    if name in _components:
+        raise ValueError(f"Component with name '{name}' already exists.")
+
+    translation = CartesianRepresentation(
+        translation_data["x"], translation_data["y"], translation_data["z"]
+    )
+    rotation = CartesianRepresentation(
+        rotation_data["x"], rotation_data["y"], rotation_data["z"]
+    )
+
+    parent_component = None
+    if parent_name:
+        parent_component = _components.get(parent_name)
+        if not parent_component:
+            raise ValueError(f"Parent component '{parent_name}' not found.")
+
+    component = Component(name, typeID, translation, rotation, parent=parent_component, extra_attrs=extra_attrs)
+    _components[name] = component
+    return name
+
+
+def get_sysmlv2_text(root_component_name: str, package_name: str = "MyStructure") -> str:
+    """
+    API endpoint to generate the SysMLv2 textual representation of the entire
+    component hierarchy, starting from a specified root component.
+    """
+    root = _components.get(root_component_name)
+    if not root:
+        raise ValueError(f"Root component '{root_component_name}' not found.")
+
+    lines = [
+        f"package {package_name} {{",
+        pu_geometry_pkg,
+        "",
+        "     part def Context {",
+        f"        part {root.name} :Component {{"
+    ]
+    for child in root.children:
+        lines.append(child.to_textual(indent=12))
+    lines.append("        }")
+    lines.append("    }")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def clear_components():
+    """Clears all components from the internal store. Useful for testing or resetting."""
+    _components.clear()
+
+
+def _values_by_name(root) -> Dict[str, str]:
+    from sysmlv2_flexo_bridge import _engine
+    model = root._model
+    if model.sysml_text is None:
+        return {}
+    return _engine.evaluate_attributes(model.sysml_text)
+
+
+_LITERAL_NUMBER_TYPES = ("LiteralRational", "LiteralInteger")
+
+
+def _find_first_literal(el):
+    """Descend through wrapper elements (e.g. a unary operator's Feature
+    operand) to find the first numeric literal, or None."""
+    if el.element_type in _LITERAL_NUMBER_TYPES:
+        return el
+    for child in el.owned_elements:
+        found = _find_first_literal(child)
+        if found is not None:
+            return found
+    return None
+
+
+def _collect_attrs(el, values_by_name: Dict[str, str]) -> Dict[str, object]:
+    """Collect numeric/string attribute values under a PartUsage element (JsonElement)."""
+    vals: Dict[str, object] = {}
+
+    def _collect_attr(e):
+        au = e.try_cast("AttributeUsage")
+        if not au:
+            return
+        expression = next(iter(au.owned_elements), None)
+        if expression is None:
+            return
+        if expression.element_type in _LITERAL_NUMBER_TYPES:
+            vals[au.name] = float(expression.value)
+        elif expression.element_type == "LiteralString":
+            vals[au.name] = str(expression.value)
+        elif expression.element_type == "OperatorExpression" and expression.data.get("operator") == "-":
+            # Negative literals (e.g. `ty=-0.19;`) parse as a unary minus
+            # OperatorExpression over a nested literal, not a plain literal —
+            # handled directly rather than via the evaluate_attributes()
+            # fallback below, which doesn't resolve this expression shape.
+            literal = _find_first_literal(expression)
+            if literal is not None:
+                vals[au.name] = -float(literal.value)
+        else:
+            name = au.qualified_name or au.name
+            result = values_by_name.get(name) or (
+                values_by_name.get(au.name) if au.name else None
+            )
+            if result is not None:
+                try:
+                    vals[au.name] = float(result)
+                except (TypeError, ValueError):
+                    pass  # unresolved expression; leave attribute unset rather than storing junk
+
+    if getattr(el, "owned_elements", None):
+        el.owned_elements.for_each(_collect_attr)
+    return vals
+
+
+def components_from_part_world(root, *, angles_in_degrees=False, euler_axes='sxyz'):
+    """
+    Traverse a PartUsage subtree (a sysmlv2_flexo_bridge JsonElement — e.g.
+    from sysmlv2_flexo_bridge.api.convert_json_to_sysml_textual's
+    model.document.root_node) and return a flat list of component dicts with:
+      - local pose (tx..rz)  : relative to parent (as in the model)
+      - absolute pose (abs_*) : world frame, recursively accumulated
+      - nearest component ancestor (parent_name/typeID)
+    Only nodes with numeric typeID are emitted as 'components'.
+
+    sysmlv2-native equivalent of geometry_api.components_from_part_world.
+    """
+    to_rad = (lambda a: a * math.pi / 180.0) if angles_in_degrees else (lambda a: a)
+    to_deg = lambda a: a * 180.0 / math.pi
+
+    def _to_float(x):
+        if isinstance(x, bool):
+            return x
+        if isinstance(x, int):
+            return x
+        try:
+            return float(x)
+        except Exception:
+            return x
+
+    def _normalize(d):
+        return {k: (_to_float(v) if not isinstance(v, (list, tuple, dict)) else v) for k, v in d.items()}
+
+    values_by_name = _values_by_name(root)
+    out = []
+
+    def visit(el, parent_state):
+        if parent_state is None:
+            parent_state = {"T": np.identity(4), "comp_parent": None}
+
+        part = el.try_cast("PartUsage")
+        next_state = dict(parent_state)
+
+        if part:
+            vals = _collect_attrs(el, values_by_name)
+
+            ltx = vals.get("tx", 0.0); lty = vals.get("ty", 0.0); ltz = vals.get("tz", 0.0)
+            lrx = to_rad(vals.get("rx", 0.0)); lry = to_rad(vals.get("ry", 0.0)); lrz = to_rad(vals.get("rz", 0.0))
+
+            T_local = transformation_matrix((ltx, lty, ltz), (lrx, lry, lrz))
+            T_abs = parent_state["T"] @ T_local
+            next_state["T"] = T_abs
+
+            arx, ary, arz = euler_from_matrix(T_abs, axes=euler_axes)
+            abs_tx, abs_ty, abs_tz = T_abs[0, 3], T_abs[1, 3], T_abs[2, 3]
+            if angles_in_degrees:
+                arx, ary, arz = to_deg(arx), to_deg(ary), to_deg(arz)
+
+            extra = dict(vals)
+            for key in ("tx", "ty", "tz", "rx", "ry", "rz", "typeID"):
+                extra.pop(key, None)
+            onshape_url = extra.pop("onshape_url", None)
+
+            rec = {
+                "name": part.name or "",
+                "typeID": int(vals.get("typeID", 0)),
+                "tx": ltx, "ty": lty, "tz": ltz,
+                "rx": vals.get("rx", 0.0), "ry": vals.get("ry", 0.0), "rz": vals.get("rz", 0.0),
+                "abs_tx": abs_tx, "abs_ty": abs_ty, "abs_tz": abs_tz,
+                "abs_rx": arx, "abs_ry": ary, "abs_rz": arz,
+                "parent_name": parent_state["comp_parent"][0] if parent_state["comp_parent"] else None,
+                "parent_typeID": parent_state["comp_parent"][1] if parent_state["comp_parent"] else None,
+                "onshape_url": onshape_url,
+                **extra,
+            }
+            out.append(_normalize(rec))
+            next_state["comp_parent"] = (rec["name"], rec["typeID"])
+
+        for child in getattr(el, "owned_elements", []):
+            visit(child, next_state)
+
+    visit(root, None)
+    return out
+
+
+def load_from_sysml(root, clear_existing: bool = True) -> "tuple[Component | None, dict[str, Component]]":
+    """
+    Inverse of get_sysmlv2_text(): reads a SysMLv2 model (a
+    sysmlv2_flexo_bridge JsonElement) starting at `root` and rebuilds the
+    Python Component hierarchy (_components dict).
+
+    sysmlv2-native equivalent of geometry_api.load_from_sysml.
+
+    Args:
+        root: a sysmlv2_flexo_bridge JsonElement (e.g. the Context or
+            Component PartUsage).
+        clear_existing: If True, clears any previous _components registry.
+    Returns:
+        The root Component object reconstructed from the model.
+    """
+    if clear_existing:
+        _components.clear()
+
+    values_by_name = _values_by_name(root)
+
+    def visit(el, parent_component=None):
+        part = el.try_cast("PartUsage")
+        if part:
+            vals = _collect_attrs(el, values_by_name)
+            def_names = [pd.name for pd in part.part_definitions]
+            has_typeid = "typeID" in vals
+            has_component_def = "Component" in def_names
+
+            if has_typeid or has_component_def:
+                type_id = int(vals.get("typeID", len(_components) + 1))
+                extra = dict(vals)
+                extra.pop("typeID", None)
+                tx = extra.pop("tx", 0.0); ty = extra.pop("ty", 0.0); tz = extra.pop("tz", 0.0)
+                rx = extra.pop("rx", 0.0); ry = extra.pop("ry", 0.0); rz = extra.pop("rz", 0.0)
+
+                this_component = Component(
+                    name=part.name or f"Unnamed_{len(_components)}",
+                    typeID=type_id,
+                    translation=CartesianRepresentation(tx, ty, tz),
+                    rotation=CartesianRepresentation(rx, ry, rz),
+                    parent=parent_component,
+                    extra_attrs=extra,
+                )
+                _components[this_component.name] = this_component
+                parent_component = this_component
+
+        for child in getattr(el, "owned_elements", []):
+            visit(child, parent_component)
+
+    visit(root, None)
+
+    roots = [c for c in _components.values() if c.parent is None]
+    return (roots[0] if roots else None), _components

--- a/tests/test_geometry_api_bridge.py
+++ b/tests/test_geometry_api_bridge.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+
+import pytest
+
+from geometry_api_bridge import (
+    create_component,
+    get_sysmlv2_text,
+    clear_components,
+    load_from_sysml,
+    components_from_part_world,
+)
+
+
+def setup_function():
+    clear_components()
+
+
+def test_create_root_component_and_generate_text():
+    name = create_component(
+        name="root",
+        typeID=1,
+        translation_data={"x": 0.0, "y": 0.0, "z": 0.0},
+        rotation_data={"x": 0.0, "y": 0.0, "z": 0.0},
+    )
+    assert name == "root"
+
+    text = get_sysmlv2_text("root", package_name="Pkg")
+    assert "package Pkg {" in text
+    assert "part def Component{" in text
+    assert "part root :Component {" in text
+
+
+def test_create_child_component_hierarchy():
+    create_component(
+        name="root",
+        typeID=1,
+        translation_data={"x": 0.0, "y": 0.0, "z": 0.0},
+        rotation_data={"x": 0.0, "y": 0.0, "z": 0.0},
+    )
+    create_component(
+        name="child",
+        typeID=2,
+        translation_data={"x": 1.0, "y": 2.0, "z": 3.0},
+        rotation_data={"x": 0.1, "y": 0.2, "z": 0.3},
+        parent_name="root",
+    )
+
+    text = get_sysmlv2_text("root")
+
+    assert "part child: Onshape_Component, Omniverse_Component subsets children {" in text
+    assert "tx=1.0;" in text
+    assert "ry=0.2;" in text
+    assert "typeID = 2;" in text
+
+
+def test_duplicate_component_raises():
+    create_component(
+        name="dup",
+        typeID=1,
+        translation_data={"x": 0.0, "y": 0.0, "z": 0.0},
+        rotation_data={"x": 0.0, "y": 0.0, "z": 0.0},
+    )
+    with pytest.raises(ValueError, match="already exists"):
+        create_component(
+            name="dup",
+            typeID=1,
+            translation_data={"x": 0.0, "y": 0.0, "z": 0.0},
+            rotation_data={"x": 0.0, "y": 0.0, "z": 0.0},
+        )
+
+
+def test_missing_parent_raises():
+    with pytest.raises(ValueError, match="Parent component 'missing' not found"):
+        create_component(
+            name="orphan",
+            typeID=3,
+            translation_data={"x": 0.0, "y": 0.0, "z": 0.0},
+            rotation_data={"x": 0.0, "y": 0.0, "z": 0.0},
+            parent_name="missing",
+        )
+
+
+def test_get_text_missing_root_raises():
+    with pytest.raises(ValueError, match="Root component 'nope' not found"):
+        get_sysmlv2_text("nope")
+
+
+def _load_geometry_example_root():
+    """sysmlv2_flexo_bridge equivalent of the syside test's
+    `syside.load_model` + `find_partusage_by_definition` setup.
+
+    sysmlv2_flexo_bridge (github.com/planetaryutilities/sysmlv2_flexo_bridge)
+    and the sysmlv2 wheel it drives are private planetaryutilities repos;
+    this repo's CI has no token to fetch them, so these two tests skip
+    gracefully rather than failing when they're not installed. Run them
+    locally with both installed (PYTHONPATH=src pytest ...) to actually
+    exercise load_from_sysml/components_from_part_world.
+    """
+    pytest.importorskip("sysmlv2_flexo_bridge")
+    from sysmlv2_flexo_bridge.api import (
+        convert_sysml_string_textual_to_json,
+        convert_json_to_sysml_textual,
+        find_partusage_by_definition,
+    )
+
+    this_dir = Path(__file__).parent
+    model_path = this_dir / "geometry_example.sysml"
+    text = model_path.read_text()
+
+    payload, _json_string = convert_sysml_string_textual_to_json(text)
+    (_sysml_text, model), warnings = convert_json_to_sysml_textual(
+        [record["payload"] for record in payload]
+    )
+    assert not warnings, f"unexpected warnings converting geometry_example.sysml: {warnings}"
+
+    context = find_partusage_by_definition(
+        model.document.root_node, "Component", usage_name="geometryroot"
+    )
+    assert context is not None, "Could not find PartUsage for geometryroot"
+    return context
+
+
+def test_load_from_sysml_and_regenerate_text():
+    context = _load_geometry_example_root()
+    root_comp, components = load_from_sysml(context)
+    assert root_comp is not None
+    # geometryroot is declared `:Component, Onshape_Component, Omniverse_Component`,
+    # so it's the only node in this fixture with "Component" in part_definitions
+    # (nexus/solari_* are typed Onshape_Component/Omniverse_Component only,
+    # matching the original Syside-backed geometry_api's semantics exactly).
+    assert "geometryroot" in components
+
+
+def test_components_from_part_world_matches_declared_pose():
+    context = _load_geometry_example_root()
+    components = components_from_part_world(context)
+    by_name = {c["name"]: c for c in components}
+
+    assert "solari_inside_simple" in by_name
+    inside = by_name["solari_inside_simple"]
+    assert inside["tx"] == pytest.approx(0.5)
+    assert inside["ty"] == pytest.approx(-0.19)
+    assert inside["tz"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- `geometry_api.py` hard-imports `syside` at module scope, so it requires a licensed Syside install even for callers who only want the parts that never touch Syside (`Component`/`create_component`/`get_sysmlv2_text`/`clear_components`).
- Adds `geometry_api_bridge`, mirroring `geometry_api`'s public API exactly, with **zero Syside dependency**: the bookkeeping half is a plain duplicate (never had an engine dependency), and `load_from_sysml`/`components_from_part_world` walk a [`sysmlv2_flexo_bridge`](https://github.com/planetaryutilities/sysmlv2_flexo_bridge) `JsonElement` tree instead of a live Syside AST.
- Consumers pick between the two based on which engine they're using, e.g.:
  ```python
  if backend == "sysmlv2":
      from geometry_api_bridge import load_from_sysml, components_from_part_world
  else:
      from geometry_api.geometry_api import load_from_sysml, components_from_part_world
  ```

## Bug found & fixed along the way
Negative literal attributes (e.g. `ty=-0.19;`) parse as a unary-minus `OperatorExpression` over a nested literal — `sysmlv2_flexo_bridge`'s `evaluate_attributes()` doesn't resolve this shape (returns an unresolved-element debug string instead of a number). Handled directly by descending into the `OperatorExpression`'s operand to find the literal.

## Test plan
- [x] 7 new tests in `tests/test_geometry_api_bridge.py`, mirroring `test_geometry_api.py`'s structure — all pass locally with `sysmlv2_flexo_bridge`/`sysmlv2` installed.
- [x] `test_components_from_part_world_matches_declared_pose` verifies the negative-literal fix against the existing `geometry_example.sysml` fixture.
- [ ] CI: `sysmlv2_flexo_bridge`/`sysmlv2` are private planetaryutilities repos this repo's CI has no token for, so the two tests exercising `load_from_sysml`/`components_from_part_world` use `pytest.importorskip` and skip gracefully rather than failing; bookkeeping tests always run. If you want full CI coverage, that needs a token secret added to this repo's Actions settings — happy to wire that up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)